### PR TITLE
Update XL config

### DIFF
--- a/dev/override.XL.yaml
+++ b/dev/override.XL.yaml
@@ -24,21 +24,21 @@ gitserver:
 
 # zoekt-webserver
 indexedSearch:
-  replicas: 5
+  replicas: 3
   resources:
     limits:
-      cpu: "11"
-      memory: 20G
+      cpu: "12"
+      memory: 16G
     requests:
       cpu: "250m"
       memory: 256M
 
 indexedSearchIndexer:
-  replicas: 5
+  replicas: 3
   resources:
     limits:
-      cpu: "4"
-      memory: 20G
+      cpu: "5"
+      memory: 10G
     requests:
       cpu: "250m"
       memory: 256M
@@ -47,8 +47,8 @@ searcher:
   replicas: 2
   resources:
     limits:
-      cpu: "18"
-      memory: 25G
+      cpu: "10"
+      memory: 16G
     requests:
       cpu: "250m"
       memory: 256M
@@ -169,6 +169,17 @@ pgsql:
     requests:
       cpu: "250m"
       memory: 256M
+  additionalConfig: |
+    max_connections = 200
+    effective_cache_size = 24GB
+    maintenance_work_mem = 2GB
+    max_connections = 500
+    max_parallel_maintenance_workers = 8
+    max_parallel_workers_per_gather = 4
+    work_mem = 10MB
+    shared_buffers = 8GB
+    max_parallel_workers = 8
+    max_worker_processes = 8
 
 redisStore:
   enabled: true


### PR DESCRIPTION
Updating with the latest config values based on the reference architecture testing and postgres config

I've copied the values directly from what was used for the testing. 
In practice the reduced limits on memory for indexSearch, indexedSearchIndexer and Searcher should cause no issues in all but outlier cases.
There shouldn't me memory contention anyway so to err on the side of caution I can revert the memory reductions if you'd prefer.