### PR TITLE
Add parallel build script + fix file permission issue

### DIFF
--- a/ami/packer/ami-builder.pkr.hcl
+++ b/ami/packer/ami-builder.pkr.hcl
@@ -10,6 +10,7 @@ packer {
 variable "instance_version" {
   description = "Version number for the AMI build"
   type        = string
+  default = "4.0.1"
 }
 
 variable "instance_sizes" {
@@ -58,50 +59,38 @@ variable "ami_regions" {
   type        = list(string)
 }
 
-data "amazon-linux" "filters" {
-  filters = {
-    name                = "amzn2-ami-kernel-*-hvm-*-x86_64-gp2"
-    architecture        = "x86_64"
-    root-device-type    = "ebs"
-    virtualization-type = "hvm"
-  }
-  most_recent = true
-  owners      = ["amazon"]
-  region      = var.ami_region
-}
-
-data "amazon-subnet" "filters" {
-  filters = {
-    "tag:Name" : "packer-build"
-  }
-  most_free = true
-  random    = false
-}
-
-data "amazon-ebs-volume" "root" {
-  delete_on_termination = true
-  device_name           = "/dev/xvda"
-  encrypted             = false
-  volume_type           = "gp3"
-  volume_size           = 50
-}
-
-data "ami-tags" "general" {
-  Name    = "production"
-  Version = var.instance_version
-}
-
 source "amazon-ebs" "size-xs" {
-  ami_name                     = "sourcegraph-XS (v${instance_version}) ${var.instance_sizes.xs.instance_type}"
+  ami_name                     = "test-XS (v${var.instance_version}) ${var.instance_sizes.xs.instance_type}"
   ami_description              = var.ami_description
   instance_type                = var.instance_sizes.xs.instance_type
   region                       = var.build_in_region
   ami_regions                  = var.ami_regions
   associate_public_ip_address  = true
-  source_ami                   = data.amazon-linux.filters.id
-  subnet_filter                = data.amazon-subnet.filters.id
+  source_ami_filter {
+    filters = {
+      name                = "amzn2-ami-kernel-*-hvm-*-x86_64-gp2"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = ["amazon"]
+  }
+  subnet_filter {
+    filters = {
+      "tag:Name" : "packer-build"
+    }
+    most_free = true
+    random    = false
+  }
   ssh_username                 = "ec2-user"
-  launch_block_device_mappings = data.amazon-ebs-volume.root.id
+  launch_block_device_mappings {
+    delete_on_termination = true
+    device_name           = "/dev/xvda"
+    encrypted             = false
+
+    volume_type = "gp3"
+    volume_size = 50
+  }
   launch_block_device_mappings {
     device_name           = "/dev/sdb"
     encrypted             = false
@@ -112,16 +101,37 @@ source "amazon-ebs" "size-xs" {
 }
 
 source "amazon-ebs" "size-s" {
-  ami_name                     = "sourcegraph-S (v${instance_version}) ${var.instance_sizes.s.instance_type}"
+  ami_name                     = "test-S (v${var.instance_version}) ${var.instance_sizes.s.instance_type}"
   ami_description              = var.ami_description
   instance_type                = var.instance_sizes.s.instance_type
   region                       = var.build_in_region
   ami_regions                  = var.ami_regions
   associate_public_ip_address  = true
-  source_ami                   = data.amazon-linux.filters.id
-  subnet_filter                = data.amazon-subnet.filters.id
+  source_ami_filter {
+    filters = {
+      name                = "amzn2-ami-kernel-*-hvm-*-x86_64-gp2"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = ["amazon"]
+  }
+  subnet_filter {
+    filters = {
+      "tag:Name" : "packer-build"
+    }
+    most_free = true
+    random    = false
+  }
   ssh_username                 = "ec2-user"
-  launch_block_device_mappings = data.amazon-ebs-volume.root.id
+  launch_block_device_mappings {
+    delete_on_termination = true
+    device_name           = "/dev/xvda"
+    encrypted             = false
+
+    volume_type = "gp3"
+    volume_size = 50
+  }
   launch_block_device_mappings {
     device_name           = "/dev/sdb"
     encrypted             = false
@@ -131,17 +141,79 @@ source "amazon-ebs" "size-s" {
   }
 }
 
+source "amazon-ebs" "size-m" {
+  ami_name                     = "test-M (v${var.instance_version}) ${var.instance_sizes.m.instance_type}"
+  ami_description              = var.ami_description
+  instance_type                = var.instance_sizes.m.instance_type
+  region                       = var.build_in_region
+  ami_regions                  = var.ami_regions
+  associate_public_ip_address  = true
+  source_ami_filter {
+    filters = {
+      name                = "amzn2-ami-kernel-*-hvm-*-x86_64-gp2"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = ["amazon"]
+  }
+  subnet_filter {
+    filters = {
+      "tag:Name" : "packer-build"
+    }
+    most_free = true
+    random    = false
+  }
+  ssh_username                 = "ec2-user"
+  launch_block_device_mappings {
+    delete_on_termination = true
+    device_name           = "/dev/xvda"
+    encrypted             = false
+
+    volume_type = "gp3"
+    volume_size = 50
+  }
+  launch_block_device_mappings {
+    device_name           = "/dev/sdb"
+    encrypted             = false
+    delete_on_termination = false
+    volume_type           = var.instance_sizes.m.data_volume_type
+    volume_size           = var.instance_sizes.m.data_volume_size
+  }
+}
+
 source "amazon-ebs" "size-l" {
-  ami_name                     = "sourcegraph-L (v${instance_version}) ${var.instance_sizes.l.instance_type}"
+  ami_name                     = "test-L (v${var.instance_version}) ${var.instance_sizes.l.instance_type}"
   ami_description              = var.ami_description
   instance_type                = var.instance_sizes.l.instance_type
   region                       = var.build_in_region
   ami_regions                  = var.ami_regions
   associate_public_ip_address  = true
-  source_ami                   = data.amazon-linux.filters.id
-  subnet_filter                = data.amazon-subnet.filters.id
+  source_ami_filter {
+    filters = {
+      name                = "amzn2-ami-kernel-*-hvm-*-x86_64-gp2"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = ["amazon"]
+  }
+  subnet_filter {
+    filters = {
+      "tag:Name" : "packer-build"
+    }
+    most_free = true
+    random    = false
+  }
   ssh_username                 = "ec2-user"
-  launch_block_device_mappings = data.amazon-ebs-volume.root.id
+  launch_block_device_mappings {
+    delete_on_termination = true
+    device_name           = "/dev/xvda"
+    encrypted             = false
+
+    volume_type = "gp3"
+    volume_size = 50
+  }
   launch_block_device_mappings {
     device_name           = "/dev/sdb"
     encrypted             = false
@@ -152,16 +224,37 @@ source "amazon-ebs" "size-l" {
 }
 
 source "amazon-ebs" "size-xl" {
-  ami_name                     = "sourcegraph-L (v${instance_version}) ${var.instance_sizes.xl.instance_type}"
+  ami_name                     = "test-XL (v${var.instance_version}) ${var.instance_sizes.xl.instance_type}"
   ami_description              = var.ami_description
   instance_type                = var.instance_sizes.xl.instance_type
   region                       = var.build_in_region
   ami_regions                  = var.ami_regions
   associate_public_ip_address  = true
-  source_ami                   = data.amazon-linux.filters.id
-  subnet_filter                = data.amazon-subnet.filters.id
+  source_ami_filter {
+    filters = {
+      name                = "amzn2-ami-kernel-*-hvm-*-x86_64-gp2"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = ["amazon"]
+  }
+  subnet_filter {
+    filters = {
+      "tag:Name" : "packer-build"
+    }
+    most_free = true
+    random    = false
+  }
   ssh_username                 = "ec2-user"
-  launch_block_device_mappings = data.amazon-ebs-volume.root.id
+  launch_block_device_mappings {
+    delete_on_termination = true
+    device_name           = "/dev/xvda"
+    encrypted             = false
+
+    volume_type = "gp3"
+    volume_size = 50
+  }
   launch_block_device_mappings {
     device_name           = "/dev/sdb"
     encrypted             = false
@@ -171,36 +264,39 @@ source "amazon-ebs" "size-xl" {
   }
 }
 
+
 build {
   name = "sourcegraph-amis"
   sources = [
     "source.amazon-ebs.size-xs",
+    "source.amazon-ebs.size-s",
+    "source.amazon-ebs.size-m",
     "source.amazon-ebs.size-l",
     "source.amazon-ebs.size-xl"
   ]
   provisioner "shell" {
     only             = ["amazon-ebs.size-xs"]
     environment_vars = ["INSTANCE_SIZE=XS", "INSTANCE_VERSION=${var.instance_version}"]
-    scripts          = ["../install/install.sh"]
+    scripts          = ["./install/install.sh"]
   }
   provisioner "shell" {
     only             = ["amazon-ebs.size-s"]
     environment_vars = ["INSTANCE_SIZE=S", "INSTANCE_VERSION=${var.instance_version}"]
-    scripts          = ["../install/install.sh"]
+    scripts          = ["./install/install.sh"]
   }
   provisioner "shell" {
     only             = ["amazon-ebs.size-m"]
     environment_vars = ["INSTANCE_SIZE=M", "INSTANCE_VERSION=${var.instance_version}"]
-    scripts          = ["../install/install.sh"]
+    scripts          = ["./install/install.sh"]
   }
   provisioner "shell" {
     only             = ["amazon-ebs.size-l"]
     environment_vars = ["INSTANCE_SIZE=L", "INSTANCE_VERSION=${var.instance_version}"]
-    scripts          = ["../install/install.sh"]
+    scripts          = ["./install/install.sh"]
   }
   provisioner "shell" {
     only             = ["amazon-ebs.size-xl"]
     environment_vars = ["INSTANCE_SIZE=XL", "INSTANCE_VERSION=${var.instance_version}"]
-    scripts          = ["../install/install.sh"]
+    scripts          = ["./install/install.sh"]
   }
 }

--- a/install/reboot.sh
+++ b/install/reboot.sh
@@ -10,6 +10,7 @@ if sudo systemctl status k3s.service | grep -q 'k3s.service failed'; then
     # Remove leftovers TLS certs and cred
     sudo rm -rf /var/lib/rancher/k3s/server/cred/ /var/lib/rancher/k3s/server/tls/
     sudo sh /usr/local/bin/k3s-killall.sh
+    sudo systemctl enable k3s
 fi
 sleep 30
 # Run install or upgrade

--- a/install/reboot.sh
+++ b/install/reboot.sh
@@ -1,37 +1,23 @@
 #!/usr/bin/bash
-set -exuo pipefail
-
 ##################### NO CHANGES REQUIRED BELOW THIS LINE #####################
-AMI_VERSION=$(cat /usr/local/bin/.sourcegraph-version)
-HELM_APP_VERSION=$(/usr/local/bin/helm history sourcegraph -o yaml --kubeconfig /etc/rancher/k3s/k3s.yaml | grep 'pp_version' | cut -d ":" -f 2 | xargs)
-VOLUME_VERSION=$(cat /mnt/data/.sourcegraph-version)
-HELM_RELEASE_STATUS=$(/usr/local/bin/helm status sourcegraph --kubeconfig /etc/rancher/k3s/k3s.yaml | grep 'STATUS' | cut -d ":" -f 2 | xargs)
+AMI_VERSION=$(cat /home/ec2-user/sourcegraph-version)
 ###############################################################################
+# Delete ingress
+/usr/local/bin/kubectl delete ingress sourcegraph-ingress
+sudo systemctl restart k3s
 # If k3s is not starting, reset it
 if sudo systemctl status k3s.service | grep -q 'k3s.service failed'; then
     # Remove leftovers TLS certs and cred
-    rm -rf /var/lib/rancher/k3s/server/cred/ /var/lib/rancher/k3s/server/tls/
-    /usr/local/bin/k3s-killall.sh
-else
-    # Delete ingress
-    /usr/local/bin/kubectl delete ingress sourcegraph-ingress
-fi
-sudo systemctl restart k3s
-# If no .sourcegraph-version file in volume, that means they are on 4.0.0
-[ ! -f "/mnt/data/.sourcegraph-version" ] && echo "4.0.0" >"/mnt/data/.sourcegraph-version"
-# Run the upgrade / install if:
-# 1. version number stored in volume has a "base" tag with the same version number
-# 2. version number stored in volume is different than instance version number
-if [ "${VOLUME_VERSION}" = "${AMI_VERSION}-base" ] || [ "${VOLUME_VERSION}" != "${AMI_VERSION}" ]; then
-    /usr/local/bin/helm upgrade --install --values /home/ec2-user/deploy/install/override.yaml --version "${AMI_VERSION}" sourcegraph /home/ec2-user/deploy/install/sourcegraph-"${AMI_VERSION}".tgz --kubeconfig /etc/rancher/k3s/k3s.yaml
-    sleep 10
-    /usr/local/bin/kubectl create -f /home/ec2-user/deploy/install/ingress.yaml
+    sudo rm -rf /var/lib/rancher/k3s/server/cred/ /var/lib/rancher/k3s/server/tls/
+    sudo sh /usr/local/bin/k3s-killall.sh
 fi
 sleep 30
+# Run install or upgrade
+# TODO: B - Compare versions before performing upgrades
+/usr/local/bin/helm upgrade --install --values /home/ec2-user/deploy/install/override.yaml --version "${AMI_VERSION}" sourcegraph /home/ec2-user/deploy/install/sourcegraph-"${AMI_VERSION}".tgz --kubeconfig /etc/rancher/k3s/k3s.yaml
+# Create ingress
+/usr/local/bin/kubectl create -f /home/ec2-user/deploy/install/ingress.yaml
 sudo systemctl restart k3s
 sleep 30
-# Check if the upgrade / install was successed before changing the stored version number
-[ "${VOLUME_VERSION}" != "${AMI_VERSION}" ] &&
-    # Update version file on disk if deployed sucessfully
-    [ "${HELM_RELEASE_STATUS}" = "deployed" ] && [ "${HELM_APP_VERSION}" = "${AMI_VERSION}" ] && echo "${AMI_VERSION}" >"/mnt/data/.sourcegraph-version"
 sudo systemctl restart k3s
+sleep 120


### PR DESCRIPTION
- Fix launch script file permission issue
- Confirmed the script `ami-builder.pkr.hcl` worked with the updated launch script as I was able to build multiple amis in parallel (only tested with 2): 
```bash
# packer build -var-file=./ami/packer/ami-variables.hcl ./ami/packer/ami-builder.pkr.hcl
Build 'sourcegraph-amis.amazon-ebs.size-s' finished after 5 minutes 24 seconds.

==> Wait completed after 5 minutes 24 seconds

==> Builds finished. The artifacts of successful builds are:
--> sourcegraph-amis.amazon-ebs.size-xs: AMIs were created:
us-west-2: ami-04824869ac44cf3ff

--> sourcegraph-amis.amazon-ebs.size-s: AMIs were created:
us-west-2: ami-0f3bc54f6d3ad7ffc
```