### PR TITLE
Fix replicaCount keys for override files

### DIFF
--- a/install/override.L.yaml
+++ b/install/override.L.yaml
@@ -3,7 +3,7 @@ storageClass:
   name: local-path
 
 frontend:
-  replicas: 2
+  replicaCount: 2
   resources:
     limits:
       cpu: "6"
@@ -13,7 +13,7 @@ frontend:
       memory: 256M
 
 gitserver:
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "8"
@@ -24,7 +24,7 @@ gitserver:
 
 # zoekt-webserver
 indexedSearch:
-  replicas: 2
+  replicaCount: 2
   resources:
     limits:
       cpu: "8"
@@ -34,7 +34,7 @@ indexedSearch:
       memory: 256M
 
 indexedSearchIndexer:
-  replicas: 2
+  replicaCount: 2
   resources:
     limits:
       cpu: "4"
@@ -44,7 +44,7 @@ indexedSearchIndexer:
       memory: 256M
 
 searcher:
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -54,7 +54,7 @@ searcher:
       memory: 256M
 
 repoUpdater:
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -63,8 +63,8 @@ repoUpdater:
       cpu: "250m"
       memory: 256M
 
-preciseCodeIntelWorker:
-  replicas: 1
+preciseCodeIntel:
+  replicaCount: 1
   resources:
     limits:
       cpu: "2"
@@ -74,7 +74,7 @@ preciseCodeIntelWorker:
       memory: 256M
 
 worker:
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -84,7 +84,7 @@ worker:
       memory: 256M
 
 syntectServer:
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -140,7 +140,7 @@ minio:
 
 codeInsightsDB:
   enabled: true
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -151,7 +151,7 @@ codeInsightsDB:
 
 codeIntelDB:
   enabled: true
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -162,7 +162,7 @@ codeIntelDB:
 
 pgsql:
   enabled: true
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -173,7 +173,7 @@ pgsql:
 
 redisStore:
   enabled: true
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "1"
@@ -184,7 +184,7 @@ redisStore:
 
 redisCache:
   enabled: true
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "1"

--- a/install/override.M.yaml
+++ b/install/override.M.yaml
@@ -3,7 +3,7 @@ storageClass:
   name: local-path
 
 frontend:
-  replicas: 2
+  replicaCount: 2
   resources:
     limits:
       cpu: "4"
@@ -13,7 +13,7 @@ frontend:
       memory: 256M
 
 gitserver:
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "6"
@@ -24,7 +24,7 @@ gitserver:
 
 # zoekt-webserver
 indexedSearch:
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "6"
@@ -34,7 +34,7 @@ indexedSearch:
       memory: 256M
 # zoekt-indexserver
 indexedSearchIndexer:
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -44,7 +44,7 @@ indexedSearchIndexer:
       memory: 256M
 
 searcher:
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "6"
@@ -54,7 +54,7 @@ searcher:
       memory: 256M
 
 repoUpdater:
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -63,8 +63,8 @@ repoUpdater:
       cpu: "250m"
       memory: 256M
 
-preciseCodeIntelWorker:
-  replicas: 1
+preciseCodeIntel:
+  replicaCount: 1
   resources:
     limits:
       cpu: "2"
@@ -74,7 +74,7 @@ preciseCodeIntelWorker:
       memory: 256M
 
 worker:
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -84,7 +84,7 @@ worker:
       memory: 256M
 
 syntectServer:
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -140,7 +140,7 @@ minio:
 
 codeInsightsDB:
   enabled: true
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -151,7 +151,7 @@ codeInsightsDB:
 
 codeIntelDB:
   enabled: true
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -162,7 +162,7 @@ codeIntelDB:
 
 pgsql:
   enabled: true
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -173,7 +173,7 @@ pgsql:
 
 redisStore:
   enabled: true
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "1"
@@ -184,7 +184,7 @@ redisStore:
 
 redisCache:
   enabled: true
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "1"

--- a/install/override.S.yaml
+++ b/install/override.S.yaml
@@ -3,7 +3,7 @@ storageClass:
   name: local-path
 
 frontend:
-  replicas: 2
+  replicaCount: 2
   resources:
     limits:
       cpu: "4"
@@ -13,7 +13,7 @@ frontend:
       memory: 256M
 
 gitserver:
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "6"
@@ -24,7 +24,7 @@ gitserver:
 
 # zoekt-webserver
 indexedSearch:
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -34,7 +34,7 @@ indexedSearch:
       memory: 256M
 # zoekt-indexserver
 indexedSearchIndexer:
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -44,7 +44,7 @@ indexedSearchIndexer:
       memory: 256M
 
 searcher:
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "6"
@@ -54,7 +54,7 @@ searcher:
       memory: 256M
 
 repoUpdater:
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -63,8 +63,8 @@ repoUpdater:
       cpu: "250m"
       memory: 256M
 
-preciseCodeIntelWorker:
-  replicas: 1
+preciseCodeIntel:
+  replicaCount: 1
   resources:
     limits:
       cpu: "2"
@@ -74,7 +74,7 @@ preciseCodeIntelWorker:
       memory: 256M
 
 worker:
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -84,7 +84,7 @@ worker:
       memory: 256M
 
 syntectServer:
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -140,7 +140,7 @@ minio:
 
 codeInsightsDB:
   enabled: true
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -151,7 +151,7 @@ codeInsightsDB:
 
 codeIntelDB:
   enabled: true
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -162,7 +162,7 @@ codeIntelDB:
 
 pgsql:
   enabled: true
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -173,7 +173,7 @@ pgsql:
 
 redisStore:
   enabled: true
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "1"
@@ -184,7 +184,7 @@ redisStore:
 
 redisCache:
   enabled: true
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "1"

--- a/install/override.XL.yaml
+++ b/install/override.XL.yaml
@@ -3,7 +3,7 @@ storageClass:
   name: local-path
 
 frontend:
-  replicas: 2
+  replicaCount: 2
   resources:
     limits:
       cpu: "9"
@@ -13,7 +13,7 @@ frontend:
       memory: 256M
 
 gitserver:
-  replicas: 2
+  replicaCount: 2
   resources:
     limits:
       cpu: "12"
@@ -24,7 +24,7 @@ gitserver:
 
 # zoekt-webserver
 indexedSearch:
-  replicas: 3
+  replicaCount: 3
   resources:
     limits:
       cpu: "12"
@@ -34,7 +34,7 @@ indexedSearch:
       memory: 256M
 
 indexedSearchIndexer:
-  replicas: 3
+  replicaCount: 3
   resources:
     limits:
       cpu: "5"
@@ -44,7 +44,7 @@ indexedSearchIndexer:
       memory: 256M
 
 searcher:
-  replicas: 2
+  replicaCount: 2
   resources:
     limits:
       cpu: "10"
@@ -54,7 +54,7 @@ searcher:
       memory: 256M
 
 repoUpdater:
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -63,8 +63,8 @@ repoUpdater:
       cpu: "250m"
       memory: 256M
 
-preciseCodeIntelWorker:
-  replicas: 1
+preciseCodeIntel:
+  replicaCount: 1
   resources:
     limits:
       cpu: "2"
@@ -74,7 +74,7 @@ preciseCodeIntelWorker:
       memory: 256M
 
 worker:
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -84,7 +84,7 @@ worker:
       memory: 256M
 
 syntectServer:
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -140,7 +140,7 @@ minio:
 
 codeInsightsDB:
   enabled: true
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -151,7 +151,7 @@ codeInsightsDB:
 
 codeIntelDB:
   enabled: true
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -162,7 +162,7 @@ codeIntelDB:
 
 pgsql:
   enabled: true
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "8"
@@ -184,7 +184,7 @@ pgsql:
 
 redisStore:
   enabled: true
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "1"
@@ -195,7 +195,7 @@ redisStore:
 
 redisCache:
   enabled: true
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "1"

--- a/install/override.XS.yaml
+++ b/install/override.XS.yaml
@@ -3,7 +3,7 @@ storageClass:
   name: local-path
 
 frontend:
-  replicas: 2
+  replicaCount: 2
   resources:
     limits:
       cpu: "4"
@@ -13,7 +13,7 @@ frontend:
       memory: 256M
 
 gitserver:
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -24,7 +24,7 @@ gitserver:
 
 # zoekt-webserver
 indexedSearch:
-  replicas: 2
+  replicaCount: 2
   resources:
     limits:
       cpu: "8"
@@ -34,7 +34,7 @@ indexedSearch:
       memory: 256M
 
 indexedSearchIndexer:
-  replicas: 2
+  replicaCount: 2
   resources:
     limits:
       cpu: "4"
@@ -44,7 +44,7 @@ indexedSearchIndexer:
       memory: 256M
 
 searcher:
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "2"
@@ -54,7 +54,7 @@ searcher:
       memory: 256M
 
 repoUpdater:
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -63,8 +63,8 @@ repoUpdater:
       cpu: "250m"
       memory: 256M
 
-preciseCodeIntelWorker:
-  replicas: 1
+preciseCodeIntel:
+  replicaCount: 1
   resources:
     limits:
       cpu: "2"
@@ -74,7 +74,7 @@ preciseCodeIntelWorker:
       memory: 256M
 
 worker:
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -84,7 +84,7 @@ worker:
       memory: 256M
 
 syntectServer:
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -130,7 +130,7 @@ minio:
 
 codeInsightsDB:
   enabled: true
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -141,7 +141,7 @@ codeInsightsDB:
 
 codeIntelDB:
   enabled: true
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -152,7 +152,7 @@ codeIntelDB:
 
 pgsql:
   enabled: true
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "4"
@@ -163,7 +163,7 @@ pgsql:
 
 redisStore:
   enabled: true
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "1"
@@ -174,7 +174,7 @@ redisStore:
 
 redisCache:
   enabled: true
-  replicas: 1
+  replicaCount: 1
   resources:
     limits:
       cpu: "1"


### PR DESCRIPTION
Current override files are misconfigured using the wrong keys for replicas and preciseCodeIntel service.

When I deploy using the XS override yaml file,  the resources are configured correctly but the values for replicas are not being respected. For example, two seachers and are deployed using the XS override file when we have specified replicas: 1:

```
default       precise-code-intel-worker-67f57fdfbf-jg76l   1/1     Running             1 (102m ago)   3d19h
default       precise-code-intel-worker-67f57fdfbf-r277n   1/1     Running             1 (102m ago)   3d19h
default       searcher-7648cd658d-skbx7                    0/1     Pending             0               3d17h
default       searcher-7648cd658d-q797c                    0/1     Pending             0               3d17h
```

This is because the correct key to modify [replicas](https://github.com/sourcegraph/deploy/blob/main/install/override.XS.yaml#L67) is [replicaCount](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/values.yaml#L431), and the service name for [preciseCodeIntelWorker](https://github.com/sourcegraph/deploy/blob/main/install/override.XS.yaml#L66) should be [preciseCodeIntel](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/main/charts/sourcegraph/values.yaml#L794)