### PR TITLE
remove minio in favor of blobstore

### DIFF
--- a/install/override.L.yaml
+++ b/install/override.L.yaml
@@ -129,7 +129,7 @@ grafana:
       cpu: "250m"
       memory: 256M
 
-minio:
+blobstore:
   enabled: true
   resources:
     limits:

--- a/install/override.M.yaml
+++ b/install/override.M.yaml
@@ -129,7 +129,7 @@ grafana:
       cpu: "250m"
       memory: 256M
 
-minio:
+blobstore:
   enabled: true
   resources:
     limits:

--- a/install/override.S.yaml
+++ b/install/override.S.yaml
@@ -129,7 +129,7 @@ grafana:
       cpu: "250m"
       memory: 256M
 
-minio:
+blobstore:
   enabled: true
   resources:
     limits:

--- a/install/override.XL.yaml
+++ b/install/override.XL.yaml
@@ -129,7 +129,7 @@ grafana:
       cpu: "250m"
       memory: 256M
 
-minio:
+blobstore:
   enabled: true
   resources:
     limits:

--- a/install/override.XS.yaml
+++ b/install/override.XS.yaml
@@ -119,7 +119,7 @@ grafana:
       cpu: "250m"
       memory: 256M
 
-minio:
+blobstore:
   enabled: true
   resources:
     limits:


### PR DESCRIPTION
`minio` support is going away, `blobstore` is the future. This is [already removed in deploy-sourcegraph-helm](https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/218) so we'll need to replace `minio` -> `blobstore` in our override files from here on out.

Helps https://github.com/sourcegraph/sourcegraph/issues/44254
