### PR TITLE
Add override for openTelemetry

### DIFF
--- a/install/override.L.yaml
+++ b/install/override.L.yaml
@@ -193,3 +193,14 @@ redisCache:
     requests:
       cpu: "250m"
       memory: 256M
+
+openTelemetry:
+  enabled: true
+  replicaCount: 1
+  resources:
+    limits:
+      cpu: "3"
+      memory: 3G
+    requests:
+      cpu: "250m"
+      memory: 256M

--- a/install/override.M.yaml
+++ b/install/override.M.yaml
@@ -193,3 +193,14 @@ redisCache:
     requests:
       cpu: "250m"
       memory: 256M
+
+openTelemetry:
+  enabled: true
+  replicaCount: 1
+  resources:
+    limits:
+      cpu: "3"
+      memory: 3G
+    requests:
+      cpu: "250m"
+      memory: 256M

--- a/install/override.S.yaml
+++ b/install/override.S.yaml
@@ -193,3 +193,14 @@ redisCache:
     requests:
       cpu: "250m"
       memory: 256M
+
+openTelemetry:
+  enabled: true
+  replicaCount: 1
+  resources:
+    limits:
+      cpu: "3"
+      memory: 3G
+    requests:
+      cpu: "250m"
+      memory: 256M

--- a/install/override.XL.yaml
+++ b/install/override.XL.yaml
@@ -204,3 +204,14 @@ redisCache:
     requests:
       cpu: "250m"
       memory: 256M
+
+openTelemetry:
+  enabled: true
+  replicaCount: 1
+  resources:
+    limits:
+      cpu: "3"
+      memory: 3G
+    requests:
+      cpu: "250m"
+      memory: 256M

--- a/install/override.XS.yaml
+++ b/install/override.XS.yaml
@@ -194,3 +194,13 @@ prometheus:
       memory: 256M
   existingConfig: prometheus-override
 
+openTelemetry:
+  enabled: true
+  replicaCount: 1
+  resources:
+    limits:
+      cpu: "3"
+      memory: 3G
+    requests:
+      cpu: "250m"
+      memory: 256M


### PR DESCRIPTION
We didn't have an override for openTelemetry meaning it was requesting the default values of 1 vCPU, 1GiB of RAM.
This caused an insufficient CPU issue on our recommended machine size of 8 CPU for XS