### PR TITLE
AWS images: remove left over keys from build process

### DIFF
--- a/packer/aws-latest/aws-builder.pkr.hcl
+++ b/packer/aws-latest/aws-builder.pkr.hcl
@@ -237,4 +237,8 @@ build {
   provisioner "shell" {
     scripts          = ["./packer/aws-latest/init.sh"]
   }
+
+  provisioner "shell" {
+    inline = ["sudo rm /home/ec2-user/.ssh/authorized_keys && sudo rm /root/.ssh/authorized_keys"]
+  }
 }

--- a/packer/aws/aws-builder.pkr.hcl
+++ b/packer/aws/aws-builder.pkr.hcl
@@ -407,4 +407,7 @@ build {
     environment_vars  = ["INSTANCE_SIZE=XS", "INSTANCE_VERSION=${var.instance_version}"]
     scripts           = ["./install/install.sh"]
   }
+  provisioner "shell" {
+    inline = ["sudo rm /home/ec2-user/.ssh/authorized_keys && sudo rm /root/.ssh/authorized_keys"]
+  }
 }


### PR DESCRIPTION
Cleanup keys that are left behind from packer during the build process. These were flagged by AWS Marketplace evaluation. 