### PR TITLE
Fix GCP symlinks

### DIFF
--- a/packer/gcp/install.sh
+++ b/packer/gcp/install.sh
@@ -12,26 +12,10 @@ USER_ROOT_PATH="/home/$INSTANCE_USERNAME/"
 DEPLOY_PATH="/home/$INSTANCE_USERNAME/deploy/install"
 SOURCEGRAPH_VERSION=$(cat /home/"$INSTANCE_USERNAME"/.sourcegraph-version)
 
-###############################################################################
-# Prepare the system
-###############################################################################
-sudo systemctl restart k3s
-# cd /home/sourcegraph/SetupWizard && /home/sourcegraph/.bun/bin/bun run server.js &
-
 if [ -f /mnt/data/.sourcegraph-version ]; then
     sleep 25 && bash $DEPLOY_PATH/reboot.sh
     exit 0
 fi
-
-if [ -f /mnt/data/.sourcegraph-size ]; then
-    SOURCEGRAPH_SIZE=$(cat /mnt/data/.sourcegraph-size)
-    cp "$HOME/deploy/install/override.$SOURCEGRAPH_SIZE.yaml" "$HOME/deploy/install/override.yaml"
-fi
-
-# cd into the deployment repository
-cd $DEPLOY_PATH || exit
-# Add version number to disk for future upgrades purpose
-sudo mkdir -p /mnt/data
 
 ###############################################################################
 # Configure data volumes
@@ -48,24 +32,25 @@ sudo echo "LABEL=/mnt/data  /mnt/data  ext4  discard,defaults,nofail  0  2" | su
 sudo umount /mnt/data
 sudo mount -a
 
-# Put ephemeral kubelet/pod storage in our data disk (since it is the only large disk we have.)
-# Symlink `/var/lib/kubelet` to `/mnt/data/kubelet`
+# Create directories
 sudo mkdir -p /mnt/data/kubelet
-sudo ln -s /mnt/data/kubelet /var/lib/kubelet
-
-# Put persistent volume pod storage in our data disk, and k3s's embedded database there too (it
-# must be kept around in order for k3s to keep PVs attached to the right folder on disk if a node
-# is lost (i.e. during an upgrade of Sourcegraph), see https://github.com/rancher/local-path-provisioner/issues/26
 sudo mkdir -p /mnt/data/db
-sudo mkdir -p /var/lib/rancher/k3s/server
-sudo ln -s /mnt/data/db /var/lib/rancher/k3s/server/db
 sudo mkdir -p /mnt/data/storage
-sudo mkdir -p /var/lib/rancher/k3s
-sudo ln -s /mnt/data/storage /var/lib/rancher/k3s/storage
 
+###############################################################################
+# Prepare the system
+###############################################################################
+if [ -f /mnt/data/.sourcegraph-size ]; then
+    SOURCEGRAPH_SIZE=$(cat /mnt/data/.sourcegraph-size)
+    cp "$HOME/deploy/install/override.$SOURCEGRAPH_SIZE.yaml" "$HOME/deploy/install/override.yaml"
+fi
+
+# cd into the deployment repository
+cd $DEPLOY_PATH || exit
 ###############################################################################
 # Install k3s (Kubernetes single-machine deployment)
 ###############################################################################
+sudo systemctl enable k3s
 sudo systemctl restart k3s
 
 # Confirm k3s and kubectl are up and running
@@ -81,6 +66,7 @@ export KUBECONFIG='/etc/rancher/k3s/k3s.yaml'
 $LOCAL_BIN_PATH/helm version --short
 
 # Create override configMap for prometheus before startup Sourcegraph
+$LOCAL_BIN_PATH/k3s kubectl apply -f /home/sourcegraph/deploy/install/prometheus-override.ConfigMap.yaml
 $LOCAL_BIN_PATH/helm --kubeconfig $KUBECONFIG_FILE upgrade -i -f /home/sourcegraph/deploy/install/override.yaml --version "$SOURCEGRAPH_VERSION" sourcegraph sourcegraph/sourcegraph
 $LOCAL_BIN_PATH/k3s kubectl create -f /home/sourcegraph/deploy/install/ingress.yaml
 
@@ -93,6 +79,7 @@ HELM_APP_VERSION=$(/usr/local/bin/helm --kubeconfig /etc/rancher/k3s/k3s.yaml hi
 [ "$SOURCEGRAPH_VERSION" == "" ] && echo "$HELM_APP_VERSION" | sudo tee "$USER_ROOT_PATH"/.sourcegraph-version
 
 # Clean up files
+mkdir "$USER_ROOT_PATH/.kube"
 sudo cp /etc/rancher/k3s/k3s.yaml /home/sourcegraph/.kube/config
 sudo rm -f /home/sourcegraph/install.sh
 sudo mv -f sourcegraph-"$HELM_APP_VERSION".tgz sourcegraph-charts.tgz


### PR DESCRIPTION
Fixes the symlink issue.
At the end of init; kill k3s; create broken symlinks to data dir.
At start of install. If existing disk then everything just works. Otherwise set up disk & dirs


- Possible known issue
  - k3s can complain about node name reuse; restarting k3s fixes it

# Test Plan
Tested images