### PR TITLE
Enable Embeddings service by default

### DIFF
--- a/install/override.L.yaml
+++ b/install/override.L.yaml
@@ -204,3 +204,16 @@ openTelemetry:
     requests:
       cpu: "250m"
       memory: 256M
+      
+embeddings:
+  enabled: true
+  env:
+    ENABLE_EMBEDDINGS_SEARCH_SIMD:
+      value: "true"
+  resources:
+    limits:
+      cpu: "7"
+      memory: 48G
+    requests:
+      cpu: "250m"
+      memory: 256M

--- a/install/override.M.yaml
+++ b/install/override.M.yaml
@@ -204,3 +204,16 @@ openTelemetry:
     requests:
       cpu: "250m"
       memory: 256M
+      
+embeddings:
+  enabled: true
+  env:
+    ENABLE_EMBEDDINGS_SEARCH_SIMD:
+      value: "true"
+  resources:
+    limits:
+      cpu: "6"
+      memory: 32G
+    requests:
+      cpu: "250m"
+      memory: 256M

--- a/install/override.S.yaml
+++ b/install/override.S.yaml
@@ -204,3 +204,16 @@ openTelemetry:
     requests:
       cpu: "250m"
       memory: 256M
+      
+embeddings:
+  enabled: true
+  env:
+    ENABLE_EMBEDDINGS_SEARCH_SIMD:
+      value: "true"
+  resources:
+    limits:
+      cpu: "5"
+      memory: 16G
+    requests:
+      cpu: "250m"
+      memory: 256M

--- a/install/override.XL.yaml
+++ b/install/override.XL.yaml
@@ -215,3 +215,16 @@ openTelemetry:
     requests:
       cpu: "250m"
       memory: 256M
+
+embeddings:
+  enabled: true
+  env:
+    ENABLE_EMBEDDINGS_SEARCH_SIMD:
+      value: "true"
+  resources:
+    limits:
+      cpu: "8"
+      memory: 64G
+    requests:
+      cpu: "250m"
+      memory: 256M

--- a/install/override.XS.yaml
+++ b/install/override.XS.yaml
@@ -204,3 +204,16 @@ openTelemetry:
     requests:
       cpu: "250m"
       memory: 256M
+
+embeddings:
+  enabled: true
+  env:
+    ENABLE_EMBEDDINGS_SEARCH_SIMD:
+      value: "true"
+  resources:
+    limits:
+      cpu: "4"
+      memory: 8G
+    requests:
+      cpu: "250m"
+      memory: 256M


### PR DESCRIPTION
On XS m6a.2xlarge this brings CPU requests to 91%. 
| Resource|           Requests   |       Limits|
  |--------   |        --------  |        ------|
 | cpu |               7300m (91%)|       86850m (1085%)|
  |memory       |      7888974464 (23%)  |223461666816 (678%)|

If embeddings are not being used the overhead for having the service run: CPU negligible (1m); MEM 40Mi