### PR TITLE
Set DEPLOY_TYPE for correct ping info

### DIFF
--- a/install/override.L.yaml
+++ b/install/override.L.yaml
@@ -11,6 +11,9 @@ frontend:
     requests:
       cpu: "250m"
       memory: 256M
+  env:
+    DEPLOY_TYPE:
+      value: k3s
 
 gitserver:
   replicaCount: 1

--- a/install/override.M.yaml
+++ b/install/override.M.yaml
@@ -11,6 +11,9 @@ frontend:
     requests:
       cpu: "250m"
       memory: 256M
+  env:
+    DEPLOY_TYPE:
+      value: k3s
 
 gitserver:
   replicaCount: 1

--- a/install/override.S.yaml
+++ b/install/override.S.yaml
@@ -11,6 +11,9 @@ frontend:
     requests:
       cpu: "250m"
       memory: 256M
+  env:
+    DEPLOY_TYPE:
+      value: k3s
 
 gitserver:
   replicaCount: 1

--- a/install/override.XL.yaml
+++ b/install/override.XL.yaml
@@ -11,6 +11,9 @@ frontend:
     requests:
       cpu: "250m"
       memory: 256M
+  env:
+    DEPLOY_TYPE:
+      value: k3s
 
 gitserver:
   replicaCount: 2

--- a/install/override.XS.yaml
+++ b/install/override.XS.yaml
@@ -11,6 +11,9 @@ frontend:
     requests:
       cpu: "250m"
       memory: 256M
+  env:
+    DEPLOY_TYPE:
+      value: k3s
 
 gitserver:
   replicaCount: 1


### PR DESCRIPTION
We don't have any ping insight into AMI installs because DEPLOY_TYPE hasn't been set correctly. This fixes that
<img width="940" alt="image" src="https://github.com/sourcegraph/deploy/assets/35706755/5c39f6a7-de5c-4e04-9e7a-3a482d39f01c">
