### PR TITLE
fix: AMIs on restart not booting up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ Use AWS CloudFormation to deploy an AMI running the latest Sourcegraph version! 
 
 ### XL -->
 
+- Fixed: Containers not able to be booted in an air gapped environment after an upgrade. 
+
 ## v5.4.2198
 
  ## Updates 

--- a/install/reboot.sh
+++ b/install/reboot.sh
@@ -54,6 +54,8 @@ if [ -f ./sourcegraph-executor-k8s-charts.tgz ]; then
 else
     $LOCAL_BIN_PATH/helm --kubeconfig $KUBECONFIG_FILE upgrade -i -f ./override.yaml --version "$AMI_VERSION" executor sourcegraph/sourcegraph-executor-k8s
 fi
+# Clear out the old pods if they're still around
+$LOCAL_BIN_PATH/kubectl delete pods --all
 
 # Restart k3s again in case it's still in crashloopbackoff
 # However, this should not affect a running instance


### PR DESCRIPTION
Resolves #57, https://github.com/sourcegraph/customer/issues/3145 and [REL-1](https://linear.app/sourcegraph/issue/REL-1/upgrading-aws-ami-instance-fails-without-internet-connectivity) by deleting pods in the `reboot.sh` script. 

Tested manually. It does work, but it does mean a bit more waiting on booting the new AMI (about 5 minutes)
