### PR TITLE
Fix: delete pods on all restarts

### DIFF
--- a/install/reboot.sh
+++ b/install/reboot.sh
@@ -10,6 +10,9 @@ LOCAL_BIN_PATH='/usr/local/bin'
 KUBECONFIG_FILE='/etc/rancher/k3s/k3s.yaml'
 RANCHER_SERVER_PATH='/var/lib/rancher/k3s/server'
 
+# Clear out the old pods if they're still around
+$LOCAL_BIN_PATH/kubectl delete pods --all
+
 ###############################################################################
 # This script will be run when instance is first started up from an AMI,
 # as well as on every system reboot.

--- a/install/reboot.sh
+++ b/install/reboot.sh
@@ -10,8 +10,6 @@ LOCAL_BIN_PATH='/usr/local/bin'
 KUBECONFIG_FILE='/etc/rancher/k3s/k3s.yaml'
 RANCHER_SERVER_PATH='/var/lib/rancher/k3s/server'
 
-# Clear out the old pods if they're still around
-$LOCAL_BIN_PATH/kubectl delete pods --all
 
 ###############################################################################
 # This script will be run when instance is first started up from an AMI,
@@ -21,6 +19,9 @@ $LOCAL_BIN_PATH/kubectl delete pods --all
 if [ -f /mnt/data/.sourcegraph-version ]; then
     VOLUME_VERSION=$(cat /mnt/data/.sourcegraph-version)
     if [ "$VOLUME_VERSION" = "$AMI_VERSION" ]; then
+        # Clear out the old pods if they're still around
+        $LOCAL_BIN_PATH/kubectl delete pods --all
+
         sudo systemctl restart k3s
         exit 0
     fi


### PR DESCRIPTION
Fix for issue where air-gapped AMIs fail to init after initial reboots. While issues this seems to be intermittent, this fix reliably solves the issue in our testing, while also increasing initial boot times.

closes https://linear.app/sourcegraph/issue/REL-147/bug-in-v545099-aws-ami-containers-not-restarting-after-reboot