### PR TITLE
fix(ci): Remove `v` from RELEASE_NUMBER

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,14 +6,17 @@ steps:
       export AWS_ACCESS_KEY_ID=$$RELEASE_AWS_ACCESS_KEY
       export AWS_SECRET_ACCESS_KEY=$$RELEASE_AWS_SECRET_KEY
       bazel run //:packer -- init --var-file=./packer/build-variables.hcl ./packer/aws/aws-builder.pkr.hcl
-      bazel run //:packer -- build -var "instance_version=$RELEASE_NUMBER" -var "dev=false" --var-file=./packer/build-variables.hcl ./packer/aws/aws-builder.pkr.hcl
+      # RELEASE_NUMBER comes from `github.ref_name` in the GHA that triggers this
+      # Tag naems now include a "v", which we remove here
+      NO_VERSION="${RELEASE_NUMBER//v}"
+      bazel run //:packer -- build -var "instance_version=$NO_VERSION" -var "dev=false" --var-file=./packer/build-variables.hcl ./packer/aws/aws-builder.pkr.hcl
       bazel run //:generate-changelog
-      git checkout -b "release/v$RELEASE_NUMBER"
+      git checkout -b "release/$RELEASE_NUMBER"
       git add CHANGELOG.md
       git commit -m "Update Changelog"
-      git push --set-upstream origin "release/v$RELEASE_NUMBER"
+      git push --set-upstream origin "release/$RELEASE_NUMBER"
       gh pr create --fill \
-        --title "Changelog Hashes for v$RELEASE_NUMBER" \
+        --title "Changelog Hashes for $RELEASE_NUMBER" \
         --body "Automated publish"
     artifact_paths:
       - "CHANGELOG.md"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,9 +7,8 @@ steps:
       export AWS_SECRET_ACCESS_KEY=$$RELEASE_AWS_SECRET_KEY
       bazel run //:packer -- init --var-file=./packer/build-variables.hcl ./packer/aws/aws-builder.pkr.hcl
       # RELEASE_NUMBER comes from `github.ref_name` in the GHA that triggers this
-      # Tag naems now include a "v", which we remove here
-      NO_VERSION="${RELEASE_NUMBER//v}"
-      bazel run //:packer -- build -var "instance_version=$NO_VERSION" -var "dev=false" --var-file=./packer/build-variables.hcl ./packer/aws/aws-builder.pkr.hcl
+      # Tag names now include a "v", which we remove here
+      bazel run //:packer -- build -var "instance_version=$$(echo $RELEASE_NUMBER | tr -d v)" -var "dev=false" --var-file=./packer/build-variables.hcl ./packer/aws/aws-builder.pkr.hcl
       bazel run //:generate-changelog
       git checkout -b "release/$RELEASE_NUMBER"
       git add CHANGELOG.md


### PR DESCRIPTION
Resolves [REL-206](https://linear.app/sourcegraph/issue/REL-206/ami-automation-buildkite-pipeline-busted) which broke when we changed the `github.ref_name` from `<VERSION>` to `v<VERSION`

## Changelog

- **fix(ci): Remove extra "v" from $RELEASE_NUMBER**
