### PR TITLE
fix install script

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -104,7 +104,8 @@ sudo ln -s /mnt/data/storage /var/lib/rancher/k3s/storage
 ###############################################################################
 # Install k3s (Kubernetes single-machine deployment)
 ###############################################################################
-curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=v1.29.3+k3s1 K3S_TOKEN=none sh -s - \
+sudo amazon-linux-extras enable selinux-ng
+curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=v1.29.7+k3s1 K3S_TOKEN=none sh -s - \
     --node-name sourcegraph-0 \
     --write-kubeconfig-mode 644 \
     --cluster-cidr 10.10.0.0/16 \


### PR DESCRIPTION
This PR fixes the install script such that it can install required selinux dependencies (even though SELinux is still disabled? I'm not sure if it was ever enabled...)

Found on [github](https://github.com/amazonlinux/amazon-linux-2023/issues/56#issuecomment-1006234810) and tested locally that it results in a working build. I also bumped the version number of k3s to the latest stable patch of the same minor release. 

Will kick off AMI builds of the failed previous builds once this is merged
