### PR TITLE
Fix reboot.sh for attaching data volume to different instance at the same version

### DIFF
--- a/install/reboot.sh
+++ b/install/reboot.sh
@@ -49,8 +49,8 @@ function check_pod_statuses() {
 
   # If any pods are not running, then call them out specifically with a warning
   PODS_NOT_RUNNING=$($KUBECTL_GET_PODS_CMD | grep -v -e Running -e Completed -e NAMESPACE -c)
-  if $PODS_NOT_RUNNING -ne 0; then
-    log "WARNING: Pods not running: "
+  if [[ $PODS_NOT_RUNNING -ne 0 ]]; then
+    log "WARNING: Pods not running:"
     grep -v -e Running -e Completed -e NAMESPACE
   fi
 }

--- a/install/reboot.sh
+++ b/install/reboot.sh
@@ -51,6 +51,7 @@ function check_pod_statuses() {
   PODS_NOT_RUNNING=$($KUBECTL_GET_PODS_CMD | grep -v -e Running -e Completed -e NAMESPACE -c)
   if [[ $PODS_NOT_RUNNING -ne 0 ]]; then
     log "WARNING: Pods not running:"
+    log "[$PODS_NOT_RUNNING]"
     grep -v -e Running -e Completed -e NAMESPACE
   fi
 }

--- a/install/reboot.sh
+++ b/install/reboot.sh
@@ -50,9 +50,8 @@ function check_pod_statuses() {
   # If any pods are not running, then call them out specifically with a warning
   PODS_NOT_RUNNING=$($KUBECTL_GET_PODS_CMD | grep -v -e Running -e Completed -e NAMESPACE -c)
   if [[ $PODS_NOT_RUNNING -ne 0 ]]; then
-    log "WARNING: Pods not running:"
-    log "[$PODS_NOT_RUNNING]"
-    grep -v -e Running -e Completed -e NAMESPACE
+    log "WARNING: $PODS_NOT_RUNNING pods not running:"
+    $KUBECTL_GET_PODS_CMD | grep -v -e Running -e Completed -e NAMESPACE
   fi
 }
 

--- a/install/reboot.sh
+++ b/install/reboot.sh
@@ -51,7 +51,7 @@ function check_pod_statuses() {
   PODS_NOT_RUNNING=$($KUBECTL_GET_PODS_CMD | grep -v -e Running -e Completed -e NAMESPACE -c)
   if [[ $PODS_NOT_RUNNING -ne 0 ]]; then
     log "WARNING: $PODS_NOT_RUNNING pods not running:"
-    $KUBECTL_GET_PODS_CMD | grep -v -e Running -e Completed -e NAMESPACE
+    $KUBECTL_GET_PODS_CMD | grep -v -e Running -e Completed
   fi
 }
 

--- a/install/reboot.sh
+++ b/install/reboot.sh
@@ -88,8 +88,7 @@ function override_coredns() {
   # This sed command appears to be safe to be re-run
   log "Overriding k3s coredns"
   sudo sed -i 's#^\(\s*\)forward .*#\1forward . 169.254.169.254 /etc/resolv.conf { policy sequential }#' $COREDNS_FILE
-  log "Restarting the k3s service"
-  $RESTART_K3S_CMD
+  restart_k3s
 }
 
 function recycle_pods_and_restart_k3s() {
@@ -100,8 +99,7 @@ function recycle_pods_and_restart_k3s() {
   sleep 60
   # Restart k3s in case pods are stuck in a crashloopbackoff
   # This should not affect a running instance
-  log "Restarting the k3s service"
-  $RESTART_K3S_CMD
+  restart_k3s
 }
 
 function reset_and_enable_k3s() {
@@ -120,6 +118,10 @@ function reset_and_enable_k3s() {
   sudo systemctl enable --now k3s
 }
 
+function restart_k3s() {
+  log "Restarting the k3s service"
+  $RESTART_K3S_CMD
+}
 
 
 ### Script execution starts here
@@ -233,8 +235,7 @@ log "Deleting ingress"
 $KUBECTL_CMD delete ingress sourcegraph-ingress
 
 # Restart the k3s service after either of the above changes
-log "Restarting the k3s service"
-$RESTART_K3S_CMD
+restart_k3s
 
 # Give k3s time to start up
 # To try and keep the user downtime as short as possible,

--- a/install/reboot.sh
+++ b/install/reboot.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/bash
+
 ###############################################################################
-# This script is run when the instance is first deployed from the AMI,
-# and on every reboot.
+# Cron runs this script on every boot
+# Customers can run this script manually
 # Logs:
-#   cron logs in /var/spool/mail/ec2-user
 #   script logs in $LOG_FILE
+#   cron logs in /var/spool/mail/$INSTANCE_USERNAME
 ###############################################################################
+
 
 ### Variables
 [ "$(whoami)" == 'ec2-user' ] && INSTANCE_USERNAME='ec2-user' || INSTANCE_USERNAME='sourcegraph'
@@ -21,6 +23,8 @@ LOCAL_SOURCEGRAPH_CHARTS_FILE="$DEPLOY_PATH/sourcegraph-charts.tgz"
 HELM_REPO="https://helm.sourcegraph.com/release"
 LOCAL_BIN_PATH='/usr/local/bin'
 RANCHER_SERVER_PATH='/var/lib/rancher/k3s/server'
+COREDNS_FILE="$RANCHER_SERVER_PATH/manifests/coredns.yaml"
+
 
 ### Reusable commands to maintain consistency for the commands this script runs multiple times
 HELM_CMD="$LOCAL_BIN_PATH/helm --kubeconfig $KUBECONFIG_FILE"
@@ -29,67 +33,120 @@ KUBECTL_CMD="$LOCAL_BIN_PATH/kubectl --kubeconfig $KUBECONFIG_FILE"
 KUBECTL_DELETE_PODS_ALL_CMD="$LOCAL_BIN_PATH/kubectl delete pods --all"
 RESTART_K3S_CMD="sudo systemctl restart k3s"
 
+
 ### Logging
 # Configure script to output to both console and file
 LOG_FILE="/var/log/reboot.sh.log"
 exec > >(sudo tee -a "$LOG_FILE") 2>&1
 
+
 ### Functions
-# Define log function for consistent output format
 function log() {
+  # Define log function for consistent output format
   echo "$(date '+%Y-%m-%d - %H:%M:%S') - $0 - $1"
 }
 
-function recycle_pods_and_restart_k3s() {
+function k3s_not_running() {
+  ! sudo systemctl status k3s.service | grep -q 'active (running)'
+}
 
+function get_sourcegraph_version_from_helm() {
+  $HELM_CMD history sourcegraph -o yaml --max 1 | grep 'app_version' | head -1 | cut -d ':' -f 2 | xargs
+}
+
+function override_coredns() {
+  # Allows for instances to resolve internal DNS in AWS / GPC VPCs via VPC metadata endpoint
+  # Before
+  # forward . /etc/resolv.conf
+  # After
+  # forward . 169.254.169.254 /etc/resolv.conf { policy sequential }
+  # This sed command appears to be safe to be re-run
+  log "Writing override to k3s coredns"
+  sudo sed -i 's#^\(\s*\)forward .*#\1forward . 169.254.169.254 /etc/resolv.conf { policy sequential }#' $COREDNS_FILE
+}
+
+function recycle_pods_and_restart_k3s() {
   log "Recycling pods"
   $KUBECTL_DELETE_PODS_ALL_CMD
-
-  log "Giving pods time to start up"
   # Could change this to a while [ kubectl get pods | grep -v Running ], with a maximum wait time of 60 seconds, then sleep 5 seconds
+  log "Giving pods 60 seconds to start up"
   sleep 60
-
   # Restart k3s in case pods are stuck in a crashloopbackoff
   # This should not affect a running instance
   log "Restarting the k3s service"
   $RESTART_K3S_CMD
 }
 
+function reset_and_enable_k3s() {
+  # install.sh leaves the k3s service disabled,
+  # so this runs on a newly deployed instance's first boot
+  # and may run if the instance is in a failing state and rebooted
+  # NOTE: Cluster data / customer content is NOT deleted in this process
+
+  log "Reenabling k3s service"
+
+  # Stop all of the K3s containers and reset the containerd state
+  sudo sh $LOCAL_BIN_PATH/k3s-killall.sh
+  # Remove leftover cred and TLS cert
+  sudo rm -rf $RANCHER_SERVER_PATH/cred/ $RANCHER_SERVER_PATH/tls/
+  # Enable and start the k3s service
+  sudo systemctl enable --now k3s
+}
+
 # Pass the version number when calling this function
 function exit_script() {
+  log "Giving a 10 second cooling period"
   sleep 10
   log "Checking pod statuses"
   $KUBECTL_CMD get pods -A
   log "Started Sourcegraph on version $1"
-  override_coredns
   log "Script finished after $(($(date +%s) - START_TIME)) seconds"
   exit 0
-}
-
-# Allows for instances to resolve internal DNS in AWS/GPC VPCs via internal metadata endpoint
-function override_coredns() {
-  log "Writing override to coredns"
-  sudo sed -i 's#^\(\s*\)forward .*#\1forward . 169.254.169.254 /etc/resolv.conf { policy sequential }#' /var/lib/rancher/k3s/server/manifests/coredns.yaml
 }
 
 ### Script execution starts here
 log "Script started"
 START_TIME=$(date +%s)
 
-### Determine the code path to take
+# Fix the DNS issue at the beginning of the script
+# so that any network connections in the script are more likely to work
+override_coredns
+
+### Get the Sourcegraph version numbers from the root and data volume
+### Try multiple sources in case there's an issue
+### Breaking this out into multiple if / then statements to avoid multilevel nested if statements
 # Get the Sourcegraph version number from the AMI's root volume
 # This should be the version of Docker images and Helm charts already baked into the AMI
 if [ -f "$AMI_ROOT_VOLUME_VERSION_FILE" ]; then
   AMI_VERSION="$(cat "$AMI_ROOT_VOLUME_VERSION_FILE")"
-  HELM_UPGRADE_INSTALL_CMD="$HELM_UPGRADE_INSTALL_CMD --version $AMI_VERSION"
   log "AMI root volume version: $AMI_VERSION"
 else
   log "WARNING: Missing AMI root volume version file at $AMI_ROOT_VOLUME_VERSION_FILE"
   # Try to install anyway
 fi
 
+# If the script wasn't able to read the $AMI_VERSION from the $AMI_ROOT_VOLUME_VERSION_FILE,
+# then try to capture it from Helm
+if [ -z "$AMI_VERSION" ]; then
+  log "WARNING: Failed to get AMI root volume version from file at $AMI_ROOT_VOLUME_VERSION_FILE"
+  AMI_VERSION=$(get_sourcegraph_version_from_helm)
+  log "Last installed version from Helm history: $AMI_VERSION"
+fi
+
+# If the script has $AMI_VERSION, then add it to the Helm command
+# Otherwise, something's broken enough for the customer to open a support ticket
+if [ -n "$AMI_VERSION" ]; then
+  # Add the version number to the Helm command
+  HELM_UPGRADE_INSTALL_CMD="$HELM_UPGRADE_INSTALL_CMD --version $AMI_VERSION"
+else
+  log "ERROR: Failed to read AMI version from either $AMI_ROOT_VOLUME_VERSION_FILE or Helm install history, contact Sourcegraph Customer Support"
+fi
+
 # Get the Sourcegraph version number from the attached data volume
 # This should be the version of the databases
+# install.sh appends '-base' to the version number on the data volume
+# to ensure that it doesn't match the version number on the root volume
+# so this script runs the whole way through on first boot
 if [ -f "$DATA_VOLUME_VERSION_FILE" ]; then
   DATA_VOLUME_VERSION="$(cat "$DATA_VOLUME_VERSION_FILE")"
   log "Data volume version: $DATA_VOLUME_VERSION"
@@ -98,21 +155,37 @@ else
   # Try to install anyway
 fi
 
-# If the customer has created an override file on the data volume, then use it, by appending it to the Helm upgrade install command
-# Always reinstall Sourcegraph on every boot when there's a custom override.yaml file
+
+### Determine the code path to take
+# If the customer has created an override file on the data volume,
+# then use it, by appending it to the Helm upgrade install command
+# Always reinstall Sourcegraph on every boot when there's a custom override.yaml file,
 # so the customer can apply these changes by rebooting the instance, or running this script
 if [ -f "$CUSTOMER_OVERRIDE_FILE" ]; then
-  # Append the customer's override file last, so that values the customer sets override our default values
-  log "Found custom Helm values file at $CUSTOMER_OVERRIDE_FILE, reinstalling Sourcegraph to use the custom Helm values file, on Sourcegraph version $AMI_VERSION"
+  log "Found custom Helm values file at $CUSTOMER_OVERRIDE_FILE, reinstalling Sourcegraph to use the custom Helm values file"
+  # Append the customer's override file to the command after the default values file, so the customer's values override the defaults we provide
   HELM_UPGRADE_INSTALL_CMD="$HELM_UPGRADE_INSTALL_CMD --values $CUSTOMER_OVERRIDE_FILE"
 
+# If the k3s service is not running, then force a reinstallation to remediate it
+elif k3s_not_running; then
+
+  if [[ $DATA_VOLUME_VERSION =~ .*-base ]]; then
+    log "First time startup, installing Sourcegraph version $AMI_VERSION"
+  else
+    log "ERROR: k3s.service is not running, reinstalling Sourcegraph version $AMI_VERSION to remediate"
+  fi
+
 # If the version on the data volume matches the version on the root volume
-# And the versions are not empty
+# and the versions are not empty
 # (not performing regex match to avoid different behaviour for non-release builds)
-# Then this is a regular reboot
+# and there's no $CUSTOMER_OVERRIDE_FILE
+# then this is a regular reboot
+# Note: if $AMI_VERSION is empty, Helm install will fail on this execution of this script
+  # Error: "helm upgrade" requires 2 arguments
+# but this execution of this script should write the most recently installed version to these files
 elif [ "$AMI_VERSION" = "$DATA_VOLUME_VERSION" ] && [ -n "$AMI_VERSION" ]; then
-  log "Versions match, starting Sourcegraph"
-  # Recycle pods and restart k3s to clear out any possible startup issues
+  log "Versions match, k3s is running, and no custom override file; starting Sourcegraph"
+  # Recycle pods and restart k3s to clear out possible startup issues
   recycle_pods_and_restart_k3s
   # Exit the script early
   exit_script "$AMI_VERSION"
@@ -122,34 +195,37 @@ else
   log "Installing Sourcegraph version $AMI_VERSION"
 fi
 
+
 ### Prepare for installation
 
-# If k3s is not starting / running successfully, then reset containerd state, so that it becomes ready for the Sourcegraph upgrade
-# NOTE: Cluster data is NOT deleted in this process
-if ! sudo systemctl status k3s.service | grep -q 'active (running)'; then
-  log "WARNING: k3s service not running, resetting state"
-  # Stop all of the K3s containers and reset the containerd state
-  sudo sh $LOCAL_BIN_PATH/k3s-killall.sh
-  # Remove leftovers TLS certs and cred
-  sudo rm -rf $RANCHER_SERVER_PATH/cred/ $RANCHER_SERVER_PATH/tls/
-  # Enable k3s in this cluster and start the unit now
-  sudo systemctl enable --now k3s
-else
-  # If k3s is running successfully, then delete the existing ingress, to prepare for the upgrade
-  log "Deleting ingress"
-  $KUBECTL_CMD delete ingress sourcegraph-ingress
+# Check if k3s is not starting / running
+# then reset containerd state
+if k3s_not_running; then
+  reset_and_enable_k3s
 fi
+
+# Delete the existing ingress, to prepare for the upgrade
+# It's fine if the ingress doesn't exist, ex. first startup, this will just print an error and continue
+# Error from server (NotFound): ingresses.networking.k8s.io "sourcegraph-ingress" not found
+# NOTE: User downtime starts now, try to keep the downtime as short as possible
+log "Deleting ingress"
+$KUBECTL_CMD delete ingress sourcegraph-ingress
 
 # Restart the k3s service after either of the above changes
 log "Restarting the k3s service"
 $RESTART_K3S_CMD
 
 # Give k3s time to start up
-log "Giving the k3s service time to start up"
-# Could change this to a while [ ! sudo systemctl status k3s.service | grep -q 'active (running)' ], with a maximum wait time of 30 seconds, then sleep 5 seconds
+# To try and keep the user downtime as short as possible,
+# we could change this to
+# while k3s_not_running()
+# with a maximum wait time of 25 seconds (log a warning if this limit is hit)
+# then sleep 5 seconds
+log "Giving the k3s service 30 seconds to start up"
 sleep 30
 
-### Install or upgrade Sourcegraph, and create ingress
+
+### Install or upgrade Sourcegraph, and recreate the ingress
 log "Changing directory to $DEPLOY_PATH"
 cd "$DEPLOY_PATH" || exit 1
 
@@ -157,64 +233,62 @@ cd "$DEPLOY_PATH" || exit 1
 log "Applying Prometheus override"
 $KUBECTL_CMD apply -f "$DEPLOY_PATH/prometheus-override.ConfigMap.yaml"
 
-# Original script's approach
-# If the Sourcegraph Helm charts exist on disk (they always should on a running instance), then use them
-# Otherwise, use the Helm charts from the Helm repo
-# Should we switch this around
-# So that if we have internet connectivity to the Helm repo
-# Then default to use it to get the latest version of the Helm charts for the Sourcegraph release version
-# And if we don't have internet connectivity
-# Then fall back to the local Helm charts on disk?
-if [ -f "$LOCAL_SOURCEGRAPH_CHARTS_FILE" ]; then
+# Prioritize updating the Helm chart from our $HELM_REPO, if reachable
+# So that customers get the latest version of the Helm chart for their Sourcegraph version
+# Helm commands have a 2 minute connection timeout that's not configurable,
+# so check if the instance has network connectivity to the Helm repo
+# before running the Helm repo update command
+CAN_CONNECT_TO_HELM_REPO=""
+if curl -s --connect-timeout 3 "$HELM_REPO" > /dev/null 2>&1; then
+  CAN_CONNECT_TO_HELM_REPO="true"
+fi
 
-  log "Upgrading Sourcegraph using Helm charts on disk at $LOCAL_SOURCEGRAPH_CHARTS_FILE"
-  $HELM_UPGRADE_INSTALL_CMD sourcegraph "$LOCAL_SOURCEGRAPH_CHARTS_FILE"
+# Install / upgrade Sourcegraph deployment
+if [ "$CAN_CONNECT_TO_HELM_REPO" ]; then
 
-elif curl -s --connect-timeout 5 "$HELM_REPO" >/dev/null 2>&1; then
-
-  # Check if the instance has network connectivity to the Helm repo, before running the Helm repo update command
-  # Helm commands have a 2 minute connection timeout that's not configurable
-  log "WARNING: Missing Sourcegraph Helm charts on disk at $LOCAL_SOURCEGRAPH_CHARTS_FILE"
-  log "Upgrading Sourcegraph using charts from $HELM_REPO"
+  log "Connection to $HELM_REPO succeeded, updating helm chart"
   $HELM_CMD repo update
+  log "Upgrading Sourcegraph using charts from $HELM_REPO"
   $HELM_UPGRADE_INSTALL_CMD sourcegraph sourcegraph/sourcegraph
 
+elif [ -f "$LOCAL_SOURCEGRAPH_CHARTS_FILE" ]; then
+
+  log "Connection to $HELM_REPO failed, upgrading Sourcegraph using Helm charts on disk at $LOCAL_SOURCEGRAPH_CHARTS_FILE"
+  $HELM_UPGRADE_INSTALL_CMD sourcegraph "$LOCAL_SOURCEGRAPH_CHARTS_FILE"
+
 else
-  log "ERROR: Missing Sourcegraph Helm charts on disk at $LOCAL_SOURCEGRAPH_CHARTS_FILE, and cannot reach Helm repo at $HELM_REPO, skipping Sourcegraph upgrade"
+  log "ERROR: Cannot reach Helm repo at $HELM_REPO, and missing Sourcegraph Helm charts on disk at $LOCAL_SOURCEGRAPH_CHARTS_FILE, skipping Sourcegraph upgrade. Contact Sourcegraph Customer Support."
 fi
 
 # Create the ingress
 log "Creating ingress"
 $KUBECTL_CMD create -f "$DEPLOY_PATH/ingress.yaml"
 
+# NOTE: User downtime can end any time from now, depending on pod startup time and success
+
 # Give the ingress time to deploy
+log "Giving the ingress 5 seconds to start up"
 sleep 5
 
-# If the Executor Helm charts exist on disk, then use them
-# Otherwise, use the Helm charts from the Helm repo
-if [ -f "$LOCAL_EXECUTOR_CHARTS_FILE" ]; then
+# Install / upgrade Executors deployment
+if [ "$CAN_CONNECT_TO_HELM_REPO" ]; then
 
-  log "Upgrading Executors using Helm charts on disk at $LOCAL_EXECUTOR_CHARTS_FILE"
-  $HELM_UPGRADE_INSTALL_CMD executor "$LOCAL_EXECUTOR_CHARTS_FILE"
-
-elif curl -s --connect-timeout 5 "$HELM_REPO" >/dev/null 2>&1; then
-
-  # Check if the instance has network connectivity to the Helm repo, before running the Helm repo update command
-  # Helm commands have a 2 minute connection timeout that's not configurable
-  log "WARNING: Missing Executors Helm charts on disk at $LOCAL_EXECUTOR_CHARTS_FILE"
   log "Upgrading Executors using charts from $HELM_REPO"
-  $HELM_CMD repo update
   $HELM_UPGRADE_INSTALL_CMD executor sourcegraph/sourcegraph-executor-k8s
 
+elif [ -f "$LOCAL_EXECUTOR_CHARTS_FILE" ]; then
+
+  log "Connection to $HELM_REPO failed, upgrading Executors using Helm charts on disk at $LOCAL_EXECUTOR_CHARTS_FILE"
+  $HELM_UPGRADE_INSTALL_CMD executor "$LOCAL_EXECUTOR_CHARTS_FILE"
+
 else
-  log "ERROR: Missing Executor Helm charts on disk at $LOCAL_EXECUTOR_CHARTS_FILE, and cannot reach Helm repo at $HELM_REPO, skipping Executor upgrade"
+  log "ERROR: Cannot reach Helm repo at $HELM_REPO, and missing executor Helm charts on disk at $LOCAL_EXECUTOR_CHARTS_FILE, skipping Executors upgrade. Contact Sourcegraph Customer Support."
 fi
 
 recycle_pods_and_restart_k3s
 
 # Write the new version number to both volumes, to pass the version match check on next reboot
-HELM_APP_VERSION="$($HELM_CMD history sourcegraph -o yaml --max 1 | grep 'app_version' | head -1 | cut -d ':' -f 2 | xargs)"
-echo "$HELM_APP_VERSION" | sudo tee "$AMI_ROOT_VOLUME_VERSION_FILE"
-echo "$HELM_APP_VERSION" | sudo tee "$DATA_VOLUME_VERSION_FILE"
+HELM_APP_VERSION=$(get_sourcegraph_version_from_helm)
+echo "$HELM_APP_VERSION" | sudo tee "$AMI_ROOT_VOLUME_VERSION_FILE" "$DATA_VOLUME_VERSION_FILE"
 
 exit_script "$HELM_APP_VERSION"


### PR DESCRIPTION
- Moved the k3s_not_running check earlier in the script to catch and remediate the case where k3s is failing to start, even if the AMI version matches the data volume version (ex. attaching data volume to different instance at the same version)
- Moved override_coredns to the start of the script fix the DNS issue before any network traffic in the script
- Created the check_pod_statuses function to provide more visibility on pod state throughout the script
- Reordered the Helm update sequence to prioritize getting the latest Helm charts from our Helm repo server, over using the Helm charts on the local disk, only if the instance can access the server, so that customer instances get the latest Helm charts for their Sourcegraph version, in case we release a fix
- Added a fallback so that the script can try to get the Sourcegraph version number from Helm if the .sourcegraph-version file is missing from the AMI
- Sorted function declarations alphabetically