### PR TITLE
feature(rel): switch to Burstable k8s QOS 

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -14,7 +14,6 @@ set -exuo pipefail
 SOURCEGRAPH_VERSION=$INSTANCE_VERSION
 SOURCEGRAPH_SIZE=$INSTANCE_SIZE
 EBS_VOLUME_DEVICE_NAME='/dev/nvme1n1'
-SOURCEGRAPH_DEPLOY_REPO_URL='https://github.com/sourcegraph/deploy'
 DEPLOY_PATH='/home/ec2-user/deploy/install'
 KUBECONFIG_FILE='/etc/rancher/k3s/k3s.yaml'
 
@@ -39,7 +38,7 @@ sudo yum update -y
 sudo yum install git -y
 
 cd $DEPLOY_PATH
-cp override."$SOURCEGRAPH_SIZE".yaml override.yaml
+cp override.burst.yaml override.yaml
 
 ###############################################################################
 # Configure EBS data volume

--- a/install/install.sh
+++ b/install/install.sh
@@ -38,9 +38,6 @@ fi
 sudo yum update -y
 sudo yum install git -y
 
-# Clone the deployment repository
-cd /home/ec2-user
-git clone $SOURCEGRAPH_DEPLOY_REPO_URL
 cd $DEPLOY_PATH
 cp override."$SOURCEGRAPH_SIZE".yaml override.yaml
 

--- a/install/override.burst.yaml
+++ b/install/override.burst.yaml
@@ -1,0 +1,187 @@
+storageClass:
+  create: false
+  name: local-path
+
+frontend:
+  replicaCount: 2
+  resources:
+    limits: null
+    requests:
+      cpu: "250m"
+      memory: 256M
+  env:
+    DEPLOY_TYPE:
+      value: k3s
+
+gitserver:
+  replicaCount: 1
+  resources:
+    limits: null
+    requests:
+      cpu: "250m"
+      memory: 256M
+  #sshSecret: gitserver-ssh
+
+# zoekt-webserver
+indexedSearch:
+  replicaCount: 2
+  resources:
+    limits: null
+    requests:
+      cpu: "250m"
+      memory: 256M
+
+indexedSearchIndexer:
+  replicaCount: 2
+  resources:
+    limits: null
+    requests:
+      cpu: "250m"
+      memory: 256M
+
+searcher:
+  replicaCount: 1
+  resources:
+    limits: null
+    requests:
+      cpu: "250m"
+      memory: 256M
+
+repoUpdater:
+  replicaCount: 1
+  resources:
+    limits: null
+    requests:
+      cpu: "250m"
+      memory: 256M
+
+preciseCodeIntel:
+  replicaCount: 1
+  resources:
+    limits: null
+    requests:
+      cpu: "250m"
+      memory: 256M
+
+worker:
+  replicaCount: 1
+  resources:
+    limits: null
+    requests:
+      cpu: "250m"
+      memory: 256M
+
+syntectServer:
+  replicaCount: 1
+  resources:
+    limits: null
+    requests:
+      cpu: "250m"
+      memory: 256M
+
+symbols:
+  resources:
+    limits: null
+    requests:
+      cpu: "250m"
+      memory: 256M
+  env:
+    # Enables Rockskip
+    USE_ROCKSKIP:
+      value: "true"
+    # Uses Rockskip for all repositories over 1GB
+    ROCKSKIP_MIN_REPO_SIZE_MB:
+      value: "1000"
+
+prometheus:
+  resources:
+    limits: null
+    requests:
+      cpu: "250m"
+      memory: 256M
+  existingConfig: prometheus-override
+
+grafana:
+  resources:
+    limits: null
+    requests:
+      cpu: "250m"
+      memory: 256M
+
+blobstore:
+  enabled: true
+  resources:
+    limits: null
+    requests:
+      cpu: "250m"
+      memory: 256M
+
+codeInsightsDB:
+  enabled: true
+  replicaCount: 1
+  resources:
+    limits: null
+    requests:
+      cpu: "250m"
+      memory: 256M
+
+codeIntelDB:
+  enabled: true
+  replicaCount: 1
+  resources:
+    limits: null
+    requests:
+      cpu: "250m"
+      memory: 256M
+
+pgsql:
+  enabled: true
+  replicaCount: 1
+  resources:
+    limits: null
+    requests:
+      cpu: "250m"
+      memory: 256M
+
+redisStore:
+  enabled: true
+  replicaCount: 1
+  resources:
+    limits: null
+    requests:
+      cpu: "250m"
+      memory: 256M
+
+redisCache:
+  enabled: true
+  replicaCount: 1
+  resources:
+    limits: null
+    requests:
+      cpu: "250m"
+      memory: 256M
+
+openTelemetry:
+  enabled: true
+  replicaCount: 1
+  resources:
+    limits: null
+    requests:
+      cpu: "250m"
+      memory: 256M
+      
+embeddings:
+  enabled: true
+  env:
+    ENABLE_EMBEDDINGS_SEARCH_SIMD:
+      value: "true"
+  resources:
+    limits: null
+    requests:
+      cpu: "250m"
+      memory: 256M
+
+executor:
+  frontendUrl: "http://sourcegraph-frontend:30080"
+  frontendPassword: "sourcegraph-ami-password"
+  queueNames: ["batches", "codeintel"]

--- a/packer/aws-latest/aws-builder.pkr.hcl
+++ b/packer/aws-latest/aws-builder.pkr.hcl
@@ -228,10 +228,15 @@ build {
     "source.amazon-ebs.io2",
   ]
 
-  // Move the install.sh script to VM to run on next reboot 
+  provisioner "shell" {
+    inline = [
+      "mkdir -p /home/ec2-user/deploy",
+    ]
+  }
+
   provisioner "file" {
-    source      = "./packer/aws-latest/install.sh"
-    destination = "/home/ec2-user/install.sh"
+    destination = "/home/ec2-user/deploy"
+    source = "./"
   }
 
   provisioner "shell" {

--- a/packer/aws-latest/init.sh
+++ b/packer/aws-latest/init.sh
@@ -5,7 +5,6 @@ set -exuo pipefail
 # Variables
 ###############################################################################
 EBS_VOLUME_DEVICE_NAME='/dev/nvme1n1'
-SOURCEGRAPH_DEPLOY_REPO_URL='https://github.com/sourcegraph/deploy'
 KUBECONFIG_FILE='/etc/rancher/k3s/k3s.yaml'
 
 ###############################################################################
@@ -30,7 +29,6 @@ sudo yum install git -y
 
 # Clone the deployment repository
 cd /home/ec2-user
-git clone $SOURCEGRAPH_DEPLOY_REPO_URL
 
 ###############################################################################
 # Configure EBS data volume

--- a/packer/aws-latest/install.sh
+++ b/packer/aws-latest/install.sh
@@ -48,7 +48,7 @@ sleep 30
 export KUBECONFIG='/etc/rancher/k3s/k3s.yaml'
 
 cd $DEPLOY_PATH || exit
-cp override."$SOURCEGRAPH_SIZE".yaml override.yaml
+cp override.burst.yaml override.yaml
 
 # Update information of available charts from Sourcegraph chart repository
 attempt=1

--- a/packer/aws/aws-builder.pkr.hcl
+++ b/packer/aws/aws-builder.pkr.hcl
@@ -398,6 +398,15 @@ build {
     "source.amazon-ebs.XL"
   ]
   provisioner "shell" {
+    inline = [
+      "mkdir -p /home/ec2-user/deploy",
+    ]
+  }
+  provisioner "file" {
+    destination = "/home/ec2-user/deploy"
+    source = "./"
+  }
+  provisioner "shell" {
     except           = ["amazon-ebs.DEV"]
     environment_vars = ["INSTANCE_SIZE=${upper(source.name)}", "INSTANCE_VERSION=${var.instance_version}"]
     scripts          = ["./install/install.sh"]

--- a/packer/gcp/gcp-builder.pkr.hcl
+++ b/packer/gcp/gcp-builder.pkr.hcl
@@ -200,7 +200,16 @@ source "googlecompute" "XL" {
 build {
   name    = "sourcegraph-amis"
   sources = local.source_group
-  // Move the install.sh script to VM to run on next reboot 
+  provisioner "shell" {
+    inline = [
+      "mkdir -p /home/sourcegraph/deploy",
+    ]
+  }
+  provisioner "file" {
+    destination = "/home/sourcegraph/deploy"
+    source = "./"
+  }
+  // Move the install.sh script to VM to run on next reboot
   provisioner "file" {
     source      = "./packer/gcp/install.sh"
     destination = "/home/sourcegraph/install.sh"

--- a/packer/gcp/init.sh
+++ b/packer/gcp/init.sh
@@ -13,7 +13,6 @@ INSTANCE_VERSION="" # e.g. 4.0.1
 ###############################################################################
 SOURCEGRAPH_VERSION=$INSTANCE_VERSION
 SOURCEGRAPH_SIZE=$INSTANCE_SIZE
-SOURCEGRAPH_DEPLOY_REPO_URL='https://github.com/sourcegraph/deploy.git'
 USER_ROOT_PATH="/home/sourcegraph"
 
 ###############################################################################
@@ -26,9 +25,8 @@ sudo apt-get update -y
 DEPLOY_PATH="$USER_ROOT_PATH/deploy/install"
 cd
 # git clone https://github.com/sourcegraph/SetupWizard.git
-git clone $SOURCEGRAPH_DEPLOY_REPO_URL
 cd "$DEPLOY_PATH" || exit 1
-cp override."$SOURCEGRAPH_SIZE".yaml override.yaml
+cp override.burst.yaml override.yaml
 
 sudo mkdir -p /mnt/data
 


### PR DESCRIPTION
Currently our AMI images implement a specific `override.<size>.yaml` file for a given T-shirt sizing. While this allows us to offer flexible fixed sizing options, it means we need to have 5 different AMI images per release (XS, S, M, L, XL).

While this was not an issue when Sourcegraph followed a quarterly release cycle, with our current 2x monthly release cycle - or possibly more - the storage and AWS public AMI quota management of additional images has lead to increase cloud expenses.

Furthermore, while 5 sizing options cover a majority of customers, customers looking to use an EC2 instance size outside of our recommended sizes are forced to manually modify their `override` file, or face wasting compute resources due to imposed service limits in our internal K8s setup.

This PR removes the internal K8s limits for services, effectively switching to [burstable](https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/#burstable) QOS in K8s. This also allows us to provide a single image that will scale dynamically to our recommended instances sizes as well as most other instances sizes provided they meet our minimum resources requests (8 vCPU, 32 Gib of memory).

Some smaller init containers or log exporter containers still implement resource limits.

This PR also switches to using the Packer [file provisioner](https://developer.hashicorp.com/packer/docs/provisioners/file#directory-uploads), rather than cloning the GH repo into the image during the build process.

## Testing

- [x] Test general AMI setup/build
- [x] Test GCP machine image setup/build
- [x] Test AMI latest setup/build
