### PR TITLE
fix: clean up volumes through CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,6 +10,7 @@ steps:
       # Tag names now include a "v", which we remove here
       bazel run //:packer -- build -var "instance_version=$$(echo $RELEASE_NUMBER | tr -d v)" -var "dev=false" --var-file=./packer/build-variables.hcl ./packer/aws/aws-builder.pkr.hcl
       bazel run //:generate-changelog
+      ./volume_cleanup.sh
       git checkout -b "release/$RELEASE_NUMBER"
       git add CHANGELOG.md
       git commit -m "Update Changelog"

--- a/volume_cleanup.sh
+++ b/volume_cleanup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Cleaning up orphaned EBS volumes..."
+aws ec2 describe-volumes \
+  --filters Name=status,Values=available \
+  --query 'Volumes[*].{ID:VolumeId}' \
+  --output text |
+  while read -r volume_id; do
+    echo "Deleting volume $volume_id"
+    aws ec2 delete-volume --volume-id "$volume_id"
+  done


### PR DESCRIPTION
Found that I had this clean up script already in the repo, so I'm adding it to the repo officially. 

I then call this script from the pipeline so it automatically cleans up the volumes. However, I'm a bit worried it'll clean up all the volumes and we may need one?
