### PR TITLE
Enable Jaeger on AMI instances

### DIFF
--- a/install/override.L.yaml
+++ b/install/override.L.yaml
@@ -207,7 +207,18 @@ openTelemetry:
     requests:
       cpu: "250m"
       memory: 256M
-      
+
+jaeger:
+  enabled: true
+  replicaCount: 1
+  resources:
+    limits:
+      cpu: "1"
+      memory: 1G
+    requests:
+      cpu: "250m"
+      memory: 256M
+
 embeddings:
   enabled: true
   env:

--- a/install/override.M.yaml
+++ b/install/override.M.yaml
@@ -207,7 +207,18 @@ openTelemetry:
     requests:
       cpu: "250m"
       memory: 256M
-      
+
+jaeger:
+  enabled: true
+  replicaCount: 1
+  resources:
+    limits:
+      cpu: "1"
+      memory: 1G
+    requests:
+      cpu: "250m"
+      memory: 256M
+
 embeddings:
   enabled: true
   env:

--- a/install/override.S.yaml
+++ b/install/override.S.yaml
@@ -207,7 +207,18 @@ openTelemetry:
     requests:
       cpu: "250m"
       memory: 256M
-      
+
+jaeger:
+  enabled: true
+  replicaCount: 1
+  resources:
+    limits:
+      cpu: "1"
+      memory: 1G
+    requests:
+      cpu: "250m"
+      memory: 256M
+
 embeddings:
   enabled: true
   env:

--- a/install/override.XL.yaml
+++ b/install/override.XL.yaml
@@ -219,6 +219,17 @@ openTelemetry:
       cpu: "250m"
       memory: 256M
 
+jaeger:
+  enabled: true
+  replicaCount: 1
+  resources:
+    limits:
+      cpu: "1"
+      memory: 1G
+    requests:
+      cpu: "250m"
+      memory: 256M
+
 embeddings:
   enabled: true
   env:

--- a/install/override.XS.yaml
+++ b/install/override.XS.yaml
@@ -208,6 +208,17 @@ openTelemetry:
       cpu: "250m"
       memory: 256M
 
+jaeger:
+  enabled: true
+  replicaCount: 1
+  resources:
+    limits:
+      cpu: "1"
+      memory: 1G
+    requests:
+      cpu: "250m"
+      memory: 256M
+
 embeddings:
   enabled: true
   env:

--- a/install/override.burst.yaml
+++ b/install/override.burst.yaml
@@ -169,7 +169,16 @@ openTelemetry:
     requests:
       cpu: "250m"
       memory: 256M
-      
+
+jaeger:
+  enabled: true
+  replicaCount: 1
+  resources:
+    limits: null
+    requests:
+      cpu: "250m"
+      memory: 256M
+
 embeddings:
   enabled: true
   env:


### PR DESCRIPTION
Enables Jaeger by default for AMI instances. 

As the intent of the AMI is minimize configuration requirements below the web UI, deploying the Jaeger container in the AMI by default removes this step. It also results in the image getting baked into the AMI, so that customers who cannot pull images from Docker Hub can still use HTTP traces when needed to troubleshoot issues with their instance. 

After / if this PR is merged, a corresponding update to the HTTP tracing docs will be made, to include the AMI https://sourcegraph.com/docs/admin/observability/tracing

Tested manually on AWS AMI