### PR TITLE
fix(rel): fix CI pipeline error

### DIFF
--- a/packer/aws/aws-builder.pkr.hcl
+++ b/packer/aws/aws-builder.pkr.hcl
@@ -404,7 +404,7 @@ build {
   }
   provisioner "file" {
     destination = "/home/ec2-user/deploy"
-    source      = "./"
+    source      = "./install"
   }
   provisioner "shell" {
     except           = ["amazon-ebs.DEV"]


### PR DESCRIPTION
This should fix the CI issue that is currently causing the build pipeline to fail. Furthermore, this cuts down the files baked into the iamge to only those needed.