### PR TITLE
Chore: Fix deployment types in telemetry

### DIFF
--- a/install/override.L.yaml
+++ b/install/override.L.yaml
@@ -13,7 +13,7 @@ frontend:
       memory: 256M
   env:
     DEPLOY_TYPE:
-      value: k3s
+      value: AMI
 
 gitserver:
   replicaCount: 1

--- a/install/override.L.yaml
+++ b/install/override.L.yaml
@@ -13,7 +13,7 @@ frontend:
       memory: 256M
   env:
     DEPLOY_TYPE:
-      value: AMI
+      value: ami
 
 gitserver:
   replicaCount: 1

--- a/install/override.M.yaml
+++ b/install/override.M.yaml
@@ -13,7 +13,7 @@ frontend:
       memory: 256M
   env:
     DEPLOY_TYPE:
-      value: k3s
+      value: AMI
 
 gitserver:
   replicaCount: 1

--- a/install/override.M.yaml
+++ b/install/override.M.yaml
@@ -13,7 +13,7 @@ frontend:
       memory: 256M
   env:
     DEPLOY_TYPE:
-      value: AMI
+      value: ami
 
 gitserver:
   replicaCount: 1

--- a/install/override.S.yaml
+++ b/install/override.S.yaml
@@ -13,7 +13,7 @@ frontend:
       memory: 256M
   env:
     DEPLOY_TYPE:
-      value: k3s
+      value: AMI
 
 gitserver:
   replicaCount: 1

--- a/install/override.S.yaml
+++ b/install/override.S.yaml
@@ -13,7 +13,7 @@ frontend:
       memory: 256M
   env:
     DEPLOY_TYPE:
-      value: AMI
+      value: ami
 
 gitserver:
   replicaCount: 1

--- a/install/override.XL.yaml
+++ b/install/override.XL.yaml
@@ -13,7 +13,7 @@ frontend:
       memory: 256M
   env:
     DEPLOY_TYPE:
-      value: k3s
+      value: AMI
 
 gitserver:
   replicaCount: 2

--- a/install/override.XL.yaml
+++ b/install/override.XL.yaml
@@ -13,7 +13,7 @@ frontend:
       memory: 256M
   env:
     DEPLOY_TYPE:
-      value: AMI
+      value: ami
 
 gitserver:
   replicaCount: 2

--- a/install/override.XS.yaml
+++ b/install/override.XS.yaml
@@ -13,7 +13,7 @@ frontend:
       memory: 256M
   env:
     DEPLOY_TYPE:
-      value: k3s
+      value: AMI
 
 gitserver:
   replicaCount: 1

--- a/install/override.XS.yaml
+++ b/install/override.XS.yaml
@@ -13,7 +13,7 @@ frontend:
       memory: 256M
   env:
     DEPLOY_TYPE:
-      value: AMI
+      value: ami
 
 gitserver:
   replicaCount: 1

--- a/install/override.burst.yaml
+++ b/install/override.burst.yaml
@@ -11,7 +11,7 @@ frontend:
       memory: 256M
   env:
     DEPLOY_TYPE:
-      value: k3s
+      value: AMI
 
 gitserver:
   replicaCount: 1

--- a/install/override.burst.yaml
+++ b/install/override.burst.yaml
@@ -11,7 +11,7 @@ frontend:
       memory: 256M
   env:
     DEPLOY_TYPE:
-      value: AMI
+      value: ami
 
 gitserver:
   replicaCount: 1


### PR DESCRIPTION
Linear issue [REL-812: Update deployment types](https://linear.app/sourcegraph/issue/REL-812/update-deployment-types)

Switching DEPLOY_TYPE from k3s to AMI, so that we can find these customer instances in telemetry more clearly. 