### PR TITLE
fix(release): remove size header from changelog generation on release

### DIFF
--- a/generate-changelog.py
+++ b/generate-changelog.py
@@ -10,7 +10,6 @@ def marshall_artifacts(artifact_id):
 
 def append_to_output(output, name, artifact_id):
     output += "\n"
-    output += "### " + name + "\n"
     output += marshall_artifacts(artifact_id) + "\n"
     return output
 


### PR DESCRIPTION
See title as well as https://github.com/sourcegraph/deploy/pull/130