### PR TITLE
Disable deprecated embeddings service

### DIFF
--- a/install/override.L.yaml
+++ b/install/override.L.yaml
@@ -220,17 +220,7 @@ jaeger:
       memory: 256M
 
 embeddings:
-  enabled: true
-  env:
-    ENABLE_EMBEDDINGS_SEARCH_SIMD:
-      value: "true"
-  resources:
-    limits:
-      cpu: "7"
-      memory: 48G
-    requests:
-      cpu: "250m"
-      memory: 256M
+  enabled: false
 
 executor:
   frontendUrl: "http://sourcegraph-frontend:30080"

--- a/install/override.M.yaml
+++ b/install/override.M.yaml
@@ -220,17 +220,7 @@ jaeger:
       memory: 256M
 
 embeddings:
-  enabled: true
-  env:
-    ENABLE_EMBEDDINGS_SEARCH_SIMD:
-      value: "true"
-  resources:
-    limits:
-      cpu: "6"
-      memory: 32G
-    requests:
-      cpu: "250m"
-      memory: 256M
+  enabled: false
 
 executor:
   frontendUrl: "http://sourcegraph-frontend:30080"

--- a/install/override.S.yaml
+++ b/install/override.S.yaml
@@ -220,17 +220,7 @@ jaeger:
       memory: 256M
 
 embeddings:
-  enabled: true
-  env:
-    ENABLE_EMBEDDINGS_SEARCH_SIMD:
-      value: "true"
-  resources:
-    limits:
-      cpu: "5"
-      memory: 16G
-    requests:
-      cpu: "250m"
-      memory: 256M
+  enabled: false
 
 executor:
   frontendUrl: "http://sourcegraph-frontend:30080"

--- a/install/override.XL.yaml
+++ b/install/override.XL.yaml
@@ -231,17 +231,7 @@ jaeger:
       memory: 256M
 
 embeddings:
-  enabled: true
-  env:
-    ENABLE_EMBEDDINGS_SEARCH_SIMD:
-      value: "true"
-  resources:
-    limits:
-      cpu: "8"
-      memory: 64G
-    requests:
-      cpu: "250m"
-      memory: 256M
+  enabled: false
 
 executor:
   frontendUrl: "http://sourcegraph-frontend:30080"

--- a/install/override.XS.yaml
+++ b/install/override.XS.yaml
@@ -220,17 +220,7 @@ jaeger:
       memory: 256M
 
 embeddings:
-  enabled: true
-  env:
-    ENABLE_EMBEDDINGS_SEARCH_SIMD:
-      value: "true"
-  resources:
-    limits:
-      cpu: "4"
-      memory: 8G
-    requests:
-      cpu: "250m"
-      memory: 256M
+  enabled: false
 
 executor:
   frontendUrl: "http://sourcegraph-frontend:30080"

--- a/install/override.burst.yaml
+++ b/install/override.burst.yaml
@@ -180,15 +180,7 @@ jaeger:
       memory: 256M
 
 embeddings:
-  enabled: true
-  env:
-    ENABLE_EMBEDDINGS_SEARCH_SIMD:
-      value: "true"
-  resources:
-    limits: null
-    requests:
-      cpu: "250m"
-      memory: 256M
+  enabled: false
 
 executor:
   frontendUrl: "http://sourcegraph-frontend:30080"


### PR DESCRIPTION
The embeddings service has been deprecated since v5.7, we should disable it