### PR TITLE
chore(release): add tagging to the AMI build pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,6 +15,8 @@ steps:
       git add CHANGELOG.md
       git commit -m "Update Changelog"
       git push --set-upstream origin "release/$RELEASE_NUMBER"
+      git tag "$RELEASE_NUMBER"
+      git push origin "$RELEASE_NUMBER"
       gh pr create --fill \
         --title "Changelog Hashes for $RELEASE_NUMBER" \
         --body "Automated publish"


### PR DESCRIPTION
This PR adds tagging the `deploy` repo at the time we build and release new AMIs. I don't believe the code is changing much in this repo on Sourcegraph version changes, but if it does this helps us keep track of it.

This is tagging the branch opened when we create a PR to update the Changelog, as the given version tag